### PR TITLE
Select copy tool by session type on Linux

### DIFF
--- a/copyStuff.lua
+++ b/copyStuff.lua
@@ -30,6 +30,24 @@ local function command_exists(cmd)
 end
 
 local function get_clipboard_cmd()
+    -- attempt to decide by current session's type
+    -- The environment variable is not a Freedesktop standard, but a Systemd one. For possible values see `man 8 pam_systemd`
+    local session_type = os.getenv("XDG_SESSION_TYPE")
+    if session_type == "wayland" then
+        if command_exists("wl-copy") then
+            return "wl-copy"
+        else
+            mp.msg.error("MPV is running in a wayland environment, but suitable command was not found")
+        end
+    elseif session_type == "x11" then
+        if command_exists("xclip") then
+            return "xclip -silent -in -selection clipboard"
+        else
+            mp.msg.error("MPV is running in an X11 environment, but suitable command was not found")
+        end
+    end
+
+    -- fallback to whatever is available
     if command_exists("xclip") then
         return "xclip -silent -in -selection clipboard"
     elseif command_exists("wl-copy") then


### PR DESCRIPTION
The former code selected xclip when MPV was running in a wayland session, because the command was existing despite it, and so copying did not work. There is also a log message now to tell the user if the copy tool was not found; on my system wl-copy is not installed by default.

I have kept the former code for compatibility, in case xclip and wl-copy is used on systems where this environment variable is not used, but of course the fix wont apply there.